### PR TITLE
issue #8 quick fix

### DIFF
--- a/hpelm/hp_elm.py
+++ b/hpelm/hp_elm.py
@@ -282,7 +282,7 @@ class HPELM(ELM):
             # process data
             Hb = self.nnet._project(Xb)
             # write data
-            H[start-start:stop-istart] = Hb
+            H[start:stop-istart] = Hb
 
             # report time
             eta = int(((time()-t0) / (b+1)) * (nb-b-1))


### PR DESCRIPTION
start-start is always 0. On the second iteration of this loop, this fails because Hb was still the chunk size, but the indexed H was double the chunk size.
Should now work as intended.